### PR TITLE
Add CasTex to Texturing/3D Generation section

### DIFF
--- a/docs/TEXTURE-AND-SURFACE-EMBEDDING-OR-MAPPING.md
+++ b/docs/TEXTURE-AND-SURFACE-EMBEDDING-OR-MAPPING.md
@@ -1,5 +1,9 @@
 ## Texture and Surface Embedding or Mapping
 
+**CasTex: Cascaded Text-to-Texture Synthesis via Explicit Texture Maps and Physically-Based Shading**<br>
+*Mishan Aliev, Dmitry Baranchuk, Kirill Struminsky.*<br>
+WACV 2026. [[PDF](https://arxiv.org/abs/2504.06856)] [[Project](https://thecrazymage.github.io/CasTex/)]
+
 **UVGS: Reimagining Unstructured 3D Gaussian Splatting using UV Mapping.**<br>
 *Aashish Rai, Dilin Wang, Mihir Jain, Nikolaos Sarafianos, Kefan Chen, Srinath Sridhar, Aayush Prakash.*<br>
 CVPR 2025. [[PDF](http://arxiv.org/abs/2502.01846)]


### PR DESCRIPTION
Hello! I would like to add our accepted paper **CasTex**. 
**Paper:** CasTex: Cascaded Text-to-Texture Synthesis via Explicit Texture Maps and Physically-Based Shading
**Authors:** Mishan Aliev, Dmitry Baranchuk, Kirill Struminsky
**Arxiv:** https://arxiv.org/abs/2504.06856 (Accepted WACV'2026)
**Project Page:** https://thecrazymage.github.io/CasTex/
**Code:** https://github.com/thecrazymage/CasTex/
**BibTeX:**
```
@article{aliev2025castex,
  title={CasTex: Cascaded Text-to-Texture Synthesis via Explicit Texture Maps and Physically-Based Shading},
  author={Aliev, Mishan and Baranchuk, Dmitry and Struminsky, Kirill},
  journal={arXiv preprint arXiv:2504.06856},
  year={2025}
}
```

**Why it fits:**
This work introduces a text-to-texture synthesis method that generates high-quality **PBR materials** (Albedo, Roughness, Metallic, Normal). Unlike previous optimization-based methods (like Paint-it or Fantasia3D) that rely on Latent Diffusion Models and suffer from oversaturation artifacts, CasTex employs **Score Distillation Sampling (SDS) in pixel space** using Cascaded Diffusion Models (DeepFloyd-IF). This approach eliminates the need for implicit regularization (DIP) and achieves state-of-the-art results on Objaverse benchmarks.


Thanks in advance for your help!